### PR TITLE
experimental changes

### DIFF
--- a/src/L.Geodesic.js
+++ b/src/L.Geodesic.js
@@ -82,32 +82,9 @@
 
     options: L.extend({},options),
 
-    initialize: function (latlngs, options) {
-      L.Polyline.prototype.initialize.call(this,latlngs,options);
-      this._geodesicConvert();
-    },
-
-    getLatLngs: function () {
-      return this._latlngsinit;
-    },
-
-    _setLatLngs: function (latlngs) {
-      this._bounds = L.latLngBounds();
-      this._latlngsinit = this._convertLatLngs(latlngs);
-    },
-
-    _defaultShape: function () {
-      var latlngs = this._latlngsinit;
-      return L.LineUtil.isFlat(latlngs) ? latlngs : latlngs[0];
-    },
-
-    redraw: function () {
-      this._geodesicConvert();
-      return L.Polyline.prototype.redraw.call(this);
-    },
-
-    _geodesicConvert: function () {
-      this._latlngs = this._geodesicConvertLines(this._latlngsinit);
+    _projectLatlngs: function (latlngs, result, projectedBounds) {
+      var geo_latlngs = this._geodesicConvertLines(latlngs);
+      L.Polyline.prototype._projectLatlngs.call(this, geo_latlngs, result, projectedBounds);
     },
 
     _geodesicConvertLine: _geodesicConvertLine,
@@ -136,25 +113,8 @@
   L.GeodesicPolyline = L.Polyline.extend(PolyMixin);
 
 
-  var PolygonMixin = L.extend(PolyMixin,{
-
-    options: L.extend({},options),
-
-    _setLatLngs: function (latlngs) {
-      L.GeodesicPolyline.prototype._setLatLngs.call(this, latlngs);
-      if (L.LineUtil.isFlat(this._latlngsinit)) {
-        this._latlngsinit = [this._latlngsinit];
-      }
-    },
-
-    _defaultShape: function () {
-      var latlngs = this._latlngsinit;
-      return L.LineUtil.isFlat(latlngs[0]) ? latlngs[0] : latlngs[0][0];
-    }
-
-  });
-
-  L.GeodesicPolygon = L.Polygon.extend(PolygonMixin);
+  PolyMixin.options = L.extend({},options); // fix: https://github.com/Leaflet/Leaflet/pull/6766
+  L.GeodesicPolygon = L.Polygon.extend(PolyMixin);
 
 
   L.GeodesicCircle = L.Polygon.extend({

--- a/src/L.Geodesic.js
+++ b/src/L.Geodesic.js
@@ -6,24 +6,33 @@
 
   function geodesicPoly(Klass, fill) {
     return Klass.extend({
+
       initialize: function (latlngs, options) {
-        Klass.prototype.initialize.call(this, L.geodesicConvertLines(latlngs, fill), options);
-        this._latlngsinit = this._convertLatLngs(latlngs);
+        Klass.prototype.initialize.call(this,latlngs,options);
+        this._geodesicConvert();
       },
+
       getLatLngs: function () {
         return this._latlngsinit;
       },
-      setLatLngs: function (latlngs) {
+
+      _setLatLngs: function (latlngs) {
+        this._bounds = L.latLngBounds();
         this._latlngsinit = this._convertLatLngs(latlngs);
-        return this.redraw();
       },
-      addLatLng: function (latlng) {
-        this._latlngsinit.push(L.latLng(latlng));
-        return this.redraw();
+
+      _defaultShape: function () {
+        var latlngs = this._latlngsinit;
+        return L.LineUtil.isFlat(latlngs) ? latlngs : latlngs[0];
       },
-      redraw: function() {
-        this._latlngs = this._convertLatLngs(L.geodesicConvertLines(this._latlngsinit, fill));
+
+      redraw: function () {
+        this._geodesicConvert();
         return Klass.prototype.redraw.call(this);
+      },
+
+      _geodesicConvert: function () {
+        this._latlngs = L.geodesicConvertLines(this._latlngsinit,fill);
       }
     });
   }
@@ -91,7 +100,7 @@
 
     // points are wrapped after being offset relative to the first point coordinate, so they're
     // within +-180 degrees
-    latlngs = latlngs.map(function(a){ return L.latLng(a.lat, a.lng-lngOffset).wrap(); });
+    latlngs = latlngs.map(function (a) { return L.latLng(a.lat, a.lng-lngOffset).wrap(); });
 
     var geodesiclatlngs = [];
 
@@ -108,7 +117,7 @@
     // now add back the offset subtracted above. no wrapping here - the drawing code handles
     // things better when there's no sudden jumps in coordinates. yes, lines will extend
     // beyond +-180 degrees - but they won't be 'broken'
-    geodesiclatlngs = geodesiclatlngs.map(function(a){ return L.latLng(a.lat, a.lng+lngOffset); });
+    geodesiclatlngs = geodesiclatlngs.map(function (a) { return L.latLng(a.lat, a.lng+lngOffset); });
 
     return geodesiclatlngs;
   };
@@ -149,11 +158,11 @@
       return this._latlng;
     },
 
-    getRadius: function() {
+    getRadius: function () {
       return this._radius;
     },
 
-    _calcPoints: function() {
+    _calcPoints: function () {
 //console.log("geodesicCircle: radius = "+this._radius+"m, centre "+this._latlng.lat+","+this._latlng.lng);
 
       // circle radius as an angle from the centre of the earth
@@ -171,7 +180,7 @@
       var cosRadRadius = Math.cos(radRadius);
       var sinRadRadius = Math.sin(radRadius);
 
-      var calcLatLngAtAngle = function(angle) {
+      var calcLatLngAtAngle = function (angle) {
         var lat = Math.asin(sinCentreLat*cosRadRadius + cosCentreLat*sinRadRadius*Math.cos(angle));
         var lng = centreLng + Math.atan2(Math.sin(angle)*sinRadRadius*cosCentreLat, cosRadRadius-sinCentreLat*Math.sin(lat));
 

--- a/src/L.Geodesic.js
+++ b/src/L.Geodesic.js
@@ -42,8 +42,6 @@
         convertedPoints.push(point);
       }
     }
-
-    convertedPoints.push(endLatLng);
   }
 
   function _geodesicConvertLines (latlngs) {
@@ -66,19 +64,7 @@
     // within +-180 degrees
     latlngs = latlngs.map(function (a) { return L.latLng(a.lat, a.lng-lngOffset).wrap(); });
 
-    var geodesiclatlngs = [];
-
-    // var isPolygon = this.options.fill; // !wrong: L.Draw use options.fill with polylines
-    var isPolygon = this instanceof L.Polygon;
-    if(!isPolygon) {
-      geodesiclatlngs.push(latlngs[0]);
-    }
-    for (var i = 0, len = latlngs.length - 1; i < len; i++) {
-      this._geodesicConvertLine(latlngs[i], latlngs[i+1], geodesiclatlngs);
-    }
-    if(isPolygon) {
-      this._geodesicConvertLine(latlngs[len], latlngs[0], geodesiclatlngs);
-    }
+    var geodesiclatlngs = this._processPoly(latlngs,this._geodesicConvertLine);
 
     // now add back the offset subtracted above. no wrapping here - the drawing code handles
     // things better when there's no sudden jumps in coordinates. yes, lines will extend
@@ -126,7 +112,25 @@
 
     _geodesicConvertLine: _geodesicConvertLine,
 
-    _geodesicConvertLines: _geodesicConvertLines
+    _geodesicConvertLines: _geodesicConvertLines,
+
+    _processPoly: function (latlngs, fn) {
+      var result = [];
+
+      // var isPolygon = this.options.fill; // !wrong: L.Draw use options.fill with polylines
+      var isPolygon = this instanceof L.Polygon;
+      if (isPolygon) {
+        latlngs.push(latlngs[0]);
+      } else {
+        result.push(latlngs[0]);
+      }
+      for (var i = 0, len = latlngs.length - 1; i < len; i++) {
+        fn.call(this,latlngs[i], latlngs[i+1], result);
+        result.push(latlngs[i+1]);
+      }
+      return result;
+    },
+
   };
 
   L.GeodesicPolyline = L.Polyline.extend(PolyMixin);


### PR DESCRIPTION
Based on ideas from https://github.com/IITC-CE/ingress-intel-total-conversion/issues/232

Main idea: do not store intermediate points.
Instead they are calculated on every projection (which typically occurs on zoom/viewreset).
- greatly simplify classes, and increase compatibility with `L.Polyline`-related routines (especially 3rd-party).
- changes in performance is unmeasured yet
  - memory footprint is lower
  - recalculations may be more frequent (unsure)


<details>
<summary>
But besides mentioned benefits there is also plenty space for future improvement
</summary>

- depend on zoom
- depend on map bounds
  - include lines/bounds intersections to points
  - clip to bounds (not calculate invisible parts)
  - more: see #2
</details>