### PR TITLE
geodesicConvertLine: calculate seg count based on distance

### DIFF
--- a/src/L.Geodesic.js
+++ b/src/L.Geodesic.js
@@ -17,7 +17,7 @@
     var distance = Math.acos(
       Math.sin(lat1) * Math.sin(lat2) +
       Math.cos(lat1) * Math.cos(lat2) * Math.cos(-dLng));
-    var segments = Math.ceil(distance * earthR / segmentLength);
+    var segments = Math.ceil((0.1 * distance + 0.9 * Math.abs(dLng)) * earthR / this.options.segmentsCoeff);
     if (segments < 2) { return; }
 
     // maths based on https://edwilliams.org/avform.htm#Int

--- a/src/L.Geodesic.js
+++ b/src/L.Geodesic.js
@@ -14,6 +14,7 @@
     var lng2 = end.lng * d2r;
     var dLng = lng1-lng2;
 
+    // Turns out the latitude distance still matters. Give it some weight.
     var distance = Math.acos(
       Math.sin(lat1) * Math.sin(lat2) +
       Math.cos(lat1) * Math.cos(lat2) * Math.cos(-dLng));

--- a/src/L.Geodesic.js
+++ b/src/L.Geodesic.js
@@ -14,7 +14,10 @@
     var lng2 = end.lng * d2r;
     var dLng = lng1-lng2;
 
-    var segments = Math.floor(Math.abs(dLng * earthR / this.options.segmentsCoeff));
+    var distance = Math.acos(
+      Math.sin(lat1) * Math.sin(lat2) +
+      Math.cos(lat1) * Math.cos(lat2) * Math.cos(-dLng));
+    var segments = Math.ceil(distance * earthR / segmentLength);
     if (segments < 2) { return; }
 
     // maths based on https://edwilliams.org/avform.htm#Int


### PR DESCRIPTION
Suggested by @johnd0e in https://github.com/IITC-CE/ingress-intel-total-conversion/issues/232#issuecomment-520220465. Should work for now, at least until we switch to the shinier Geodesic addon by henrythasler.

(About a potential switch: henrythasler's thing uses a WGS84 ellipsoid. https://github.com/IITC-CE/ingress-intel-total-conversion/issues/232#issuecomment-517763552 says stock uses https://github.com/chrisveness/geodesy, but it's unclear whether stock uses the spherical formula from Chris or the WGS84 ellipsoid one. If it's the former [quite likely!],  henrythasler's thing won't work for us.)